### PR TITLE
#39651 Fixed - The tax state code for the Indian state of Chhattisgar…

### DIFF
--- a/plugins/woocommerce/i18n/states.php
+++ b/plugins/woocommerce/i18n/states.php
@@ -782,7 +782,7 @@ return array(
 		'AR' => __( 'Arunachal Pradesh', 'woocommerce' ),
 		'AS' => __( 'Assam', 'woocommerce' ),
 		'BR' => __( 'Bihar', 'woocommerce' ),
-		'CT' => __( 'Chhattisgarh', 'woocommerce' ),
+		'CG' => __( 'Chhattisgarh', 'woocommerce' ),
 		'GA' => __( 'Goa', 'woocommerce' ),
 		'GJ' => __( 'Gujarat', 'woocommerce' ),
 		'HR' => __( 'Haryana', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39651.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Visit WooCommerce > Settings > Tax > Standard rates and add Chhattisgarh as the state of a tax line.
The value of CT is returned.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->
Changed Chhattisgarh Indian State Code to CG from CT.

<details>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

</details>
